### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,49 +2,49 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Sprite		KEYWORD1
+Sprite	KEYWORD1
 #VecSprite	KEYWORD1
-NMT_GFX		KEYWORD1
+NMT_GFX	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-block_color		KEYWORD2
-tile_color		KEYWORD2
-begin			KEYWORD2
-end				KEYWORD2
-line			KEYWORD2
-w_vram			KEYWORD2
-translatef		KEYWORD2
-rotatef			KEYWORD2
-w_vram_long		KEYWORD2
-w_vram_word		KEYWORD2
-render_3d		KEYWORD2
-frame_3d		KEYWORD2
-add_line		KEYWORD2
-del_line		KEYWORD2
-sprite			KEYWORD2
-write_at		KEYWORD2
-set_color		KEYWORD2
-fill			KEYWORD2
-fast			KEYWORD2
-box				KEYWORD2
-clear			KEYWORD2
+block_color	KEYWORD2
+tile_color	KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+line	KEYWORD2
+w_vram	KEYWORD2
+translatef	KEYWORD2
+rotatef	KEYWORD2
+w_vram_long	KEYWORD2
+w_vram_word	KEYWORD2
+render_3d	KEYWORD2
+frame_3d	KEYWORD2
+add_line	KEYWORD2
+del_line	KEYWORD2
+sprite	KEYWORD2
+write_at	KEYWORD2
+set_color	KEYWORD2
+fill	KEYWORD2
+fast	KEYWORD2
+box	KEYWORD2
+clear	KEYWORD2
 binary_image	KEYWORD2
-fill			KEYWORD2
-fill_box		KEYWORD2
-pixel			KEYWORD2
-set_size		KEYWORD2
-set_center		KEYWORD2
+fill	KEYWORD2
+fill_box	KEYWORD2
+pixel	KEYWORD2
+set_size	KEYWORD2
+set_center	KEYWORD2
 set_cursor_pos	KEYWORD2
-x_tiles			KEYWORD2
-y_tiles			KEYWORD2
-write_at		KEYWORD2
-get_size_x		KEYWORD2
-get_size_y		KEYWORD2
-upload			KEYWORD2
-make_color		KEYWORD2
+x_tiles	KEYWORD2
+y_tiles	KEYWORD2
+write_at	KEYWORD2
+get_size_x	KEYWORD2
+get_size_y	KEYWORD2
+upload	KEYWORD2
+make_color	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords